### PR TITLE
Welcome page v3: team agent pitch + HubSpot waitlist (lp-a-team-agent)

### DIFF
--- a/astro-src/pages/welcome.astro
+++ b/astro-src/pages/welcome.astro
@@ -18,7 +18,7 @@ import PostHogInit from '../../src/components/PostHogInit';
 
 const title = "Desktop Commander: You're all set. Now meet your team's agent.";
 const description =
-  "Your Desktop Commander MCP is installed. Next: set up a shared agent for your team with shared files, shared tools, and its own computer. Connect your ERP, CRM, and databases, and talk to your stuff.";
+  "Your Desktop Commander MCP is installed. Next: set up a team agent with shared files, shared tools, and its own computer. Connect your ERP, CRM, and databases, and talk to your stuff.";
 ---
 
 <!DOCTYPE html>
@@ -268,7 +268,7 @@ const description =
     text-transform: uppercase; color: var(--text-faint); white-space: nowrap;
   }
 
-  /* ---------- pitch: shared agent ---------- */
+  /* ---------- pitch: team agent ---------- */
   .pitch { padding: 70px 0 30px; text-align: center; }
   .pitch h2 {
     font-family: var(--display);
@@ -650,13 +650,13 @@ const description =
     <div class="divider"><span>while you're here · new</span></div>
   </header>
 
-  <!-- ============ PITCH: SHARED AGENT ============ -->
+  <!-- ============ PITCH: TEAM AGENT ============ -->
   <section class="pitch">
     <h2>Get your <span class="grad">AI employee.</span></h2>
-    <p class="sub">A shared agent that does work for your team, with <strong>shared files</strong>, <strong>shared tools</strong>, and <strong>its own computer</strong>. Everyone can talk to it.</p>
+    <p class="sub">An agent that does work for your team, with <strong>shared files</strong>, <strong>shared tools</strong>, and <strong>its own computer</strong>. Everyone can talk to it.</p>
 
     <div class="btn-row">
-      <button class="btn" data-cta="hero">Create your shared agent →</button>
+      <button class="btn" data-cta="hero">Create your team agent →</button>
     </div>
   </section>
 
@@ -733,7 +733,7 @@ const description =
     <div class="how">
       <article class="how-item">
         <div class="how-head"><span class="how-node"><b>01</b></span><span class="how-label">Create</span></div>
-        <h3 class="how-title">Create a shared agent</h3>
+        <h3 class="how-title">Create a team agent</h3>
         <p class="how-desc">Set up once for your whole team.</p>
         <svg class="how-wm" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2l1.7 5.1L19 9l-5.3 1.9L12 16l-1.7-5.1L5 9l5.3-1.9z"/><path d="M18.5 13.5l.7 2.1 2.1.7-2.1.7-.7 2.1-.7-2.1-2.1-.7 2.1-.7z"/></svg>
       </article>
@@ -754,7 +754,7 @@ const description =
     </div>
 
     <div class="btn-row">
-      <button class="btn" data-cta="bottom">Create your shared agent →</button>
+      <button class="btn" data-cta="bottom">Create your team agent →</button>
     </div>
     <div class="btn-note">early access · limited team slots</div>
   </section>
@@ -764,7 +764,7 @@ const description =
     <div class="gate-card">
       <div class="gate-inner">
         <div class="section-kicker">Early access</div>
-        <h2 class="section-title">Create your shared agent</h2>
+        <h2 class="section-title">Create your team agent</h2>
         <p class="section-sub">We're onboarding teams in small batches. Leave your company email and we'll reach out when your team's slot opens.</p>
         <div class="hs-form-frame" data-region="eu1" data-form-id="733e0a8d-9b22-4a87-8872-f2196531544c" data-portal-id="146727725"></div>
         <p class="form-note">no spam · one email when your team's slot opens</p>

--- a/astro-src/pages/welcome.astro
+++ b/astro-src/pages/welcome.astro
@@ -1,327 +1,985 @@
 ---
-import Layout from '../layouts/Layout.astro';
 import PostHogInit from '../../src/components/PostHogInit';
-import SimpleNav from '../components/SimpleNav.astro';
-import Footer from '../../src/components/Footer';
+
+/*
+  welcome.astro — v3 "team agent" design (Jun 2026).
+  Source experiment: About DC/landing-experiments/a-team-agent.html (lp-a-team-agent).
+  Previous v2 design recoverable from git history; welcome2.astro still holds v1.
+
+  Notes:
+  - Standalone document (does NOT use Layout.astro): the design ships its own
+    fonts, reset and styles, and the shared Tailwind globals would fight it.
+    Head essentials (favicons, canonical, OG, Cookiebot, GA, Ahrefs) are
+    replicated below — keep in sync with Layout.astro if those change.
+  - Email capture: HubSpot embedded form (portal 146727725 / eu1).
+  - Funnel events go to PostHog with { experiment: 'lp-a-team-agent' }:
+    page_view → cta_clicked (hero|bottom) → gate_viewed → email_submitted (+ demo_viewed)
+*/
+
+const title = "Desktop Commander: You're all set. Now meet your team's agent.";
+const description =
+  "Your Desktop Commander MCP is installed. Next: set up a shared agent for your team with shared files, shared tools, and its own computer. Connect your ERP, CRM, and databases, and talk to your stuff.";
 ---
 
-<!--
-  welcome.astro — v2 design (Apr 2026).
-  Previous version preserved at welcome2.astro for A/B comparison until retired.
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{title}</title>
+  <meta name="description" content={description} />
+  <meta name="author" content="Desktop Commander" />
 
-  Design goals:
-  - Kill every signal that could imply "there's more to install"
-  - Remove "Download App" CTA from nav on this route (SimpleNav = logo only)
-  - Anchor user inside Claude Desktop with a spatial map (here → there)
-  - Keep prompt grid as primary action; troubleshooting as quiet fallback
--->
+  <!-- Favicon -->
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="shortcut icon" href="/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="canonical" href="https://desktopcommander.app/welcome/" />
 
-<Layout
-  title="Desktop Commander is ready in Claude Desktop"
-  description="Desktop Commander MCP is installed in Claude Desktop. Pick a prompt and paste it into your Claude chat."
->
-  <PostHogInit client:load />
+  <!-- Open Graph -->
+  <meta property="og:site_name" content="Desktop Commander" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:title" content={title} />
+  <meta property="og:description" content={description} />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://desktopcommander.app/welcome/" />
+  <meta property="og:image" content="https://desktopcommander.app/bg-social-share.png" />
 
-  <div class="min-h-screen bg-background">
-    <SimpleNav />
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:site" content="@desktop_commander" />
+  <meta name="twitter:title" content={title} />
+  <meta name="twitter:description" content={description} />
+  <meta name="twitter:image" content="https://desktopcommander.app/bg-social-share.png" />
 
-    <main class="pt-24 pb-16 md:pt-28 md:pb-24">
-      <div class="container mx-auto max-w-3xl px-4 sm:px-6">
+  <meta name="robots" content="index, follow, noai, noimageai" />
+  <meta name="googlebot" content="index, follow, noai" />
 
-        <!-- Hero -->
-        <header class="text-center mb-12 md:mb-14 animate-fade-in-up">
-          <!-- "MCP server installed" pill -->
-          <div class="inline-flex items-center gap-2 px-3.5 py-1.5 mb-8 rounded-full border border-green-500/40 bg-green-500/10 text-green-400 text-[11px] font-semibold uppercase tracking-[0.08em] font-mono">
-            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M20 6 9 17l-5-5"/>
-            </svg>
-            MCP Server Installed
+  <!-- Cookiebot - MUST be first script in head -->
+  <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="83cceb09-32d2-409b-ada6-17cc28478ba6" data-blockingmode="auto" type="text/javascript" async is:inline></script>
+
+  <!-- Google tag (gtag.js) - blocked until statistics consent -->
+  <script type="text/plain" data-cookieconsent="statistics" async src="https://www.googletagmanager.com/gtag/js?id=G-HXL4Y3Y62N" is:inline></script>
+  <script type="text/plain" data-cookieconsent="statistics" is:inline>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-HXL4Y3Y62N');
+  </script>
+
+  <!-- Ahrefs Analytics - blocked until statistics consent -->
+  <script type="text/plain" data-cookieconsent="statistics" src="https://analytics.ahrefs.com/analytics.js" data-key="5Iumy4Rr7Do+R0CWUtQkHA" async is:inline></script>
+
+  <!-- HubSpot embedded form (email gate). data-cookieconsent="ignore" so
+       Cookiebot auto-blocking never prevents the form from rendering. -->
+  <script src="https://js-eu1.hsforms.net/forms/embed/146727725.js" defer data-cookieconsent="ignore" is:inline></script>
+
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://api.fontshare.com/v2/css?f[]=clash-display@500,600,700&f[]=satoshi@400,500,700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+
+  <style is:global>
+  :root {
+    --bg: #07080B;
+    --glass: rgba(255,255,255,0.035);
+    --glass-bright: rgba(255,255,255,0.06);
+    --stroke: rgba(255,255,255,0.09);
+    --stroke-bright: rgba(255,255,255,0.18);
+    --text: #F4F5F7;
+    --text-dim: #A2A7B3;
+    --text-faint: #626772;
+    --blue: #7DA9FF;
+    --violet: #A78BFA;
+    --cyan: #67E8F9;
+    --green: #4ADE80;
+    --grad: linear-gradient(100deg, #7DA9FF 0%, #A78BFA 55%, #67E8F9 110%);
+    --mono: 'JetBrains Mono', monospace;
+    --display: 'Clash Display', sans-serif;
+    --body: 'Satoshi', sans-serif;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--body);
+    line-height: 1.6;
+    overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
+  }
+  ::selection { background: var(--blue); color: #07080B; }
+
+  /* ---------- atmosphere ---------- */
+  .aurora {
+    position: fixed; inset: -20%;
+    z-index: 0; pointer-events: none;
+    filter: blur(90px) saturate(130%);
+    opacity: 0.5;
+  }
+  .aurora::before, .aurora::after {
+    content: ''; position: absolute; border-radius: 50%;
+  }
+  .aurora::before {
+    width: 55vw; height: 55vw; left: 8%; top: -12%;
+    background: radial-gradient(circle at 30% 30%, rgba(125,169,255,0.55), transparent 65%);
+    animation: drift1 26s ease-in-out infinite alternate;
+  }
+  .aurora::after {
+    width: 45vw; height: 45vw; right: 2%; top: 6%;
+    background: radial-gradient(circle at 60% 40%, rgba(167,139,250,0.4), transparent 65%);
+    animation: drift2 32s ease-in-out infinite alternate;
+  }
+  @keyframes drift1 { from { transform: translate(0,0) scale(1); } to { transform: translate(8vw,6vh) scale(1.15); } }
+  @keyframes drift2 { from { transform: translate(0,0) scale(1.1); } to { transform: translate(-10vw,10vh) scale(0.95); } }
+
+  .grain {
+    position: fixed; inset: 0; z-index: 1; pointer-events: none;
+    opacity: 0.5; mix-blend-mode: overlay;
+  }
+
+  .wrap { position: relative; z-index: 2; max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+
+  /* ---------- nav ---------- */
+  nav {
+    position: sticky; top: 14px; z-index: 50;
+    display: flex; align-items: center; justify-content: space-between;
+    margin: 14px 0 0;
+    padding: 12px 20px;
+    border: 1px solid var(--stroke);
+    border-radius: 16px;
+    background: rgba(10,11,15,0.55);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+  }
+  .logo { display: flex; align-items: center; gap: 10px; font-family: var(--display); font-weight: 600; font-size: 18px; color: var(--text); text-decoration: none; }
+  .logo-mark {
+    width: 28px; height: 28px; border-radius: 8px;
+    background: var(--text); color: var(--bg);
+    display: grid; place-items: center;
+    font-family: var(--mono); font-weight: 700; font-size: 13px;
+  }
+  .nav-note { font-family: var(--mono); font-size: 10.5px; color: var(--text-dim); letter-spacing: 0.16em; text-transform: uppercase; }
+  .dot-live { display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: var(--green); margin-right: 7px; animation: pulse 2s infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
+
+  /* ---------- hero: installed confirmation ---------- */
+  header { padding: 72px 0 0; text-align: center; }
+  .hero-card {
+    max-width: 700px; margin: 0 auto;
+    padding: 56px 44px 48px;
+    border-radius: 30px;
+    background: linear-gradient(180deg, rgba(74,222,128,0.06), rgba(255,255,255,0.02) 60%);
+    border: 1px solid rgba(74,222,128,0.25);
+    box-shadow: 0 30px 80px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.07);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    animation: rise 0.7s cubic-bezier(0.16,1,0.3,1) both;
+  }
+  .hero-card .status-line {
+    font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.2em;
+    text-transform: uppercase; color: var(--green);
+    margin-bottom: 26px;
+  }
+  .scroll-cue {
+    margin: 56px auto 0;
+    width: 52px; height: 52px;
+    border-radius: 50%;
+    display: grid; place-items: center;
+    color: var(--blue);
+    background: rgba(125,169,255,0.08);
+    border: 1px solid rgba(125,169,255,0.4);
+    box-shadow: 0 0 30px rgba(125,169,255,0.25);
+    cursor: pointer;
+    animation: cueBounce 2s ease-in-out infinite;
+  }
+  .scroll-cue:hover { background: rgba(125,169,255,0.16); }
+  @keyframes cueBounce {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(10px); }
+  }
+  .check-big {
+    width: 74px; height: 74px; margin: 0 auto;
+    border-radius: 50%;
+    background: rgba(74,222,128,0.08);
+    border: 1px solid rgba(74,222,128,0.4);
+    display: grid; place-items: center;
+    position: relative;
+    animation: rise 0.7s cubic-bezier(0.16,1,0.3,1) both;
+  }
+  .check-big::before, .check-big::after {
+    content: ''; position: absolute; inset: -12px; border-radius: 50%;
+    border: 1px solid rgba(74,222,128,0.25);
+    animation: ringPulse 2.8s ease-out infinite;
+  }
+  .check-big::after { animation-delay: 1.4s; }
+  @keyframes ringPulse {
+    0% { transform: scale(0.85); opacity: 0.9; }
+    100% { transform: scale(1.5); opacity: 0; }
+  }
+  h1 {
+    font-family: var(--display);
+    font-size: clamp(34px, 5vw, 52px);
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    line-height: 1.06;
+    margin: 26px auto 14px;
+    max-width: 860px;
+    animation: rise 0.7s 0.08s cubic-bezier(0.16,1,0.3,1) both;
+  }
+  h1 .grad {
+    background: var(--grad);
+    -webkit-background-clip: text; background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+  .sub {
+    font-size: 18.5px; color: var(--text-dim); max-width: 600px; margin: 0 auto;
+    animation: rise 0.7s 0.16s cubic-bezier(0.16,1,0.3,1) both;
+  }
+  .sub strong { color: var(--text); font-weight: 500; }
+  .hero-skip {
+    margin-top: 26px;
+    animation: rise 0.7s 0.24s cubic-bezier(0.16,1,0.3,1) both;
+  }
+  .hero-skip a {
+    font-family: var(--mono); font-size: 12px; letter-spacing: 0.06em;
+    color: var(--text-dim); text-decoration: none;
+    border-bottom: 1px solid var(--stroke-bright);
+    padding-bottom: 2px;
+  }
+  .hero-skip a:hover { color: var(--text); }
+  @keyframes rise { from { opacity: 0; transform: translateY(22px); } to { opacity: 1; transform: none; } }
+
+  /* divider between hero and pitch */
+  .divider {
+    display: flex; align-items: center; gap: 18px;
+    max-width: 720px; margin: 110px auto 0;
+    animation: rise 0.7s 0.3s cubic-bezier(0.16,1,0.3,1) both;
+  }
+  .divider::before, .divider::after {
+    content: ''; flex: 1; height: 1px;
+    background: linear-gradient(90deg, transparent, var(--stroke-bright));
+  }
+  .divider::after { background: linear-gradient(90deg, var(--stroke-bright), transparent); }
+  .divider span {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.22em;
+    text-transform: uppercase; color: var(--text-faint); white-space: nowrap;
+  }
+
+  /* ---------- pitch: shared agent ---------- */
+  .pitch { padding: 70px 0 30px; text-align: center; }
+  .pitch h2 {
+    font-family: var(--display);
+    font-size: clamp(38px, 6vw, 64px);
+    font-weight: 600;
+    letter-spacing: -0.025em;
+    line-height: 1.05;
+    max-width: 820px; margin: 0 auto 20px;
+  }
+  .pitch h2 .grad {
+    background: var(--grad);
+    -webkit-background-clip: text; background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+  .pitch .sub { max-width: 620px; }
+
+  .btn {
+    display: inline-flex; align-items: center; gap: 10px;
+    font-family: var(--display); font-weight: 600; font-size: 17px;
+    color: #0B0C10;
+    background: var(--grad);
+    border: none; border-radius: 14px;
+    padding: 17px 36px;
+    cursor: pointer;
+    transition: transform 0.15s, box-shadow 0.15s;
+    box-shadow: 0 10px 40px rgba(125,169,255,0.25);
+  }
+  .btn:hover { transform: translateY(-2px); box-shadow: 0 14px 50px rgba(125,169,255,0.4); }
+  .btn-row { margin-top: 38px; }
+  .btn-note { margin-top: 14px; font-family: var(--mono); font-size: 11.5px; color: var(--text-faint); letter-spacing: 0.04em; }
+
+  .section-kicker {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.2em;
+    text-transform: uppercase; color: var(--text-faint); margin-bottom: 14px;
+  }
+  .section-title {
+    font-family: var(--display); font-weight: 600;
+    font-size: clamp(28px, 4vw, 42px); letter-spacing: -0.02em;
+    margin-bottom: 10px;
+  }
+  .section-sub { color: var(--text-dim); font-size: 16.5px; max-width: 580px; margin: 0 auto; }
+
+  /* ---------- product demo animation ---------- */
+  .demo-section { padding: 90px 0 20px; text-align: center; }
+  .demo-shell {
+    max-width: 680px; margin: 38px auto 0;
+    border-radius: 22px; padding: 1px;
+    background: linear-gradient(160deg, rgba(125,169,255,0.45), rgba(255,255,255,0.06) 40%, rgba(167,139,250,0.35));
+    box-shadow: 0 36px 100px rgba(0,0,0,0.6);
+    text-align: left;
+  }
+  .demo-window { background: #0B0D12; border-radius: 21px; overflow: hidden; }
+  .demo-bar {
+    display: flex; align-items: center; gap: 8px;
+    padding: 13px 18px;
+    border-bottom: 1px solid var(--stroke);
+    background: rgba(255,255,255,0.02);
+  }
+  .demo-dot { width: 11px; height: 11px; border-radius: 50%; }
+  .demo-dot.r { background: #FF5F57; } .demo-dot.y { background: #FEBC2E; } .demo-dot.g { background: #28C840; }
+  .demo-title { margin-left: 10px; font-weight: 700; font-size: 13.5px; }
+  .demo-members { margin-left: auto; display: flex; align-items: center; }
+  .demo-mini-av {
+    width: 22px; height: 22px; border-radius: 50%;
+    border: 2px solid #0B0D12; margin-left: -7px;
+    display: grid; place-items: center;
+    font-family: var(--display); font-size: 9.5px; font-weight: 600; color: #fff;
+  }
+  .demo-status {
+    margin-left: 12px;
+    font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em;
+    color: var(--green); text-transform: uppercase;
+  }
+  .demo-status .sdot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: var(--green); margin-right: 6px; animation: pulse 1.6s infinite; }
+  .demo-body {
+    padding: 24px 22px 26px;
+    display: flex; flex-direction: column; gap: 14px;
+    min-height: 540px;
+    font-size: 14.5px;
+    transition: opacity 0.5s;
+  }
+  .d-msg { max-width: 88%; animation: rise 0.45s cubic-bezier(0.16,1,0.3,1) both; }
+  .d-user-row {
+    align-self: flex-end;
+    display: flex; flex-direction: row-reverse; gap: 10px;
+    max-width: 88%;
+    animation: rise 0.45s cubic-bezier(0.16,1,0.3,1) both;
+  }
+  .d-uavatar {
+    width: 32px; height: 32px; border-radius: 50%; flex-shrink: 0;
+    display: grid; place-items: center;
+    font-family: var(--display); font-weight: 600; font-size: 13px; color: #fff;
+    border: 1.5px solid rgba(255,255,255,0.25);
+    margin-top: 16px;
+  }
+  .d-uname {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+    color: var(--text-faint); text-align: right; margin: 0 4px 4px 0;
+  }
+  .d-user {
+    background: var(--grad);
+    color: #0B0C10; font-weight: 500;
+    border-radius: 16px 16px 4px 16px;
+    padding: 12px 17px;
+    line-height: 1.45;
+  }
+  .d-user.alt { background: linear-gradient(100deg, #67E8F9 0%, #7DA9FF 100%); }
+  .d-user .caret { display: inline-block; width: 2px; height: 15px; background: #0B0C10; vertical-align: -2px; margin-left: 1px; animation: caretBlink 0.9s steps(1) infinite; }
+  @keyframes caretBlink { 50% { opacity: 0; } }
+  .d-agent {
+    align-self: flex-start;
+    display: flex; gap: 12px;
+  }
+  .d-avatar {
+    width: 36px; height: 36px; border-radius: 11px; flex-shrink: 0;
+    background: linear-gradient(150deg, #1A1D26, #0D0F14);
+    border: 1px solid var(--stroke-bright);
+    display: grid; place-items: center;
+    font-family: var(--mono); font-weight: 700; font-size: 12px;
+    box-shadow: 0 0 16px rgba(125,169,255,0.22);
+  }
+  .d-bubble {
+    background: rgba(255,255,255,0.04);
+    border: 1px solid var(--stroke);
+    border-radius: 4px 16px 16px 16px;
+    padding: 13px 17px;
+    line-height: 1.5; color: #D6D9DF;
+  }
+  .d-bubble strong { color: var(--text); }
+  .d-steps { display: flex; flex-direction: column; gap: 7px; font-family: var(--mono); font-size: 12px; }
+  .d-step { color: var(--text-faint); transition: color 0.3s; animation: rise 0.4s both; }
+  .d-step .ic { display: inline-block; width: 16px; color: var(--blue); }
+  .d-step.done { color: var(--text-dim); }
+  .d-step.done .ic { color: var(--green); }
+  .d-step .spin {
+    display: inline-block; width: 10px; height: 10px;
+    border: 1.5px solid rgba(125,169,255,0.3); border-top-color: var(--blue);
+    border-radius: 50%; animation: spinr 0.8s linear infinite;
+  }
+  @keyframes spinr { to { transform: rotate(360deg); } }
+  .d-report {
+    margin-top: 12px;
+    border: 1px solid var(--stroke);
+    background: rgba(255,255,255,0.025);
+    border-radius: 14px;
+    padding: 16px 18px 14px;
+    max-width: 360px;
+  }
+  .d-report-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+  .d-report-title { font-weight: 700; font-size: 13px; }
+  .d-report-tag { font-family: var(--mono); font-size: 9.5px; color: var(--blue); background: rgba(125,169,255,0.12); border-radius: 4px; padding: 2px 7px; letter-spacing: 0.08em; }
+  .d-chart { display: flex; align-items: flex-end; gap: 7px; height: 74px; }
+  .d-chart span {
+    flex: 1; border-radius: 4px 4px 2px 2px;
+    background: linear-gradient(180deg, rgba(125,169,255,0.95), rgba(167,139,250,0.5));
+    height: 4px;
+    transition: height 0.9s cubic-bezier(0.16,1,0.3,1);
+  }
+  .d-chart span:last-child { background: linear-gradient(180deg, #67E8F9, rgba(103,232,249,0.4)); }
+  .d-chart-labels { display: flex; gap: 7px; margin-top: 7px; font-family: var(--mono); font-size: 9px; color: var(--text-faint); }
+  .d-chart-labels i { flex: 1; text-align: center; font-style: normal; }
+  .d-file {
+    margin-top: 12px;
+    display: flex; align-items: center; gap: 11px;
+    border-top: 1px solid var(--stroke);
+    padding-top: 12px;
+  }
+  .d-file-ic {
+    width: 30px; height: 30px; border-radius: 8px;
+    background: #E0466B; color: #fff;
+    display: grid; place-items: center;
+    font-family: var(--mono); font-size: 8.5px; font-weight: 700;
+  }
+  .d-file-name { font-weight: 700; font-size: 12.5px; }
+  .d-file-meta { font-family: var(--mono); font-size: 10.5px; color: var(--text-faint); }
+  .d-presence {
+    font-family: var(--mono); font-size: 11px; color: var(--text-faint);
+    padding-left: 6px;
+    animation: rise 0.3s both;
+  }
+  .d-presence::after { content: '…'; animation: pulse 1.2s infinite; }
+  .d-reacts { display: flex; gap: 7px; margin-top: 12px; }
+  .d-react {
+    font-family: var(--mono); font-size: 11px; color: var(--text-dim);
+    background: rgba(255,255,255,0.05);
+    border: 1px solid var(--stroke);
+    border-radius: 100px;
+    padding: 4px 11px;
+    animation: rise 0.4s both;
+  }
+
+  /* ---------- talk to your stuff ---------- */
+  .stuff-section { padding: 90px 0 30px; text-align: center; }
+  .tool-cloud {
+    display: flex; flex-wrap: wrap; gap: 10px; justify-content: center;
+    max-width: 760px; margin: 34px auto 0;
+  }
+  .cloud-pill {
+    font-family: var(--mono); font-size: 12.5px;
+    color: var(--text-dim);
+    background: var(--glass);
+    border: 1px solid var(--stroke);
+    border-radius: 100px;
+    padding: 10px 19px;
+    backdrop-filter: blur(8px);
+    transition: all 0.2s;
+  }
+  .cloud-pill:hover { color: var(--text); border-color: var(--stroke-bright); transform: translateY(-2px); }
+  .cloud-pill.hl { color: var(--blue); border-color: rgba(125,169,255,0.35); background: rgba(125,169,255,0.06); }
+
+  .ask-grid {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px;
+    max-width: 920px; margin: 44px auto 0; text-align: left;
+  }
+  @media (max-width: 760px) { .ask-grid { grid-template-columns: 1fr; } }
+  .ask-card {
+    background: var(--glass);
+    border: 1px solid var(--stroke);
+    border-radius: 18px;
+    padding: 22px 24px;
+    backdrop-filter: blur(10px);
+    transition: border-color 0.2s, transform 0.2s;
+  }
+  .ask-card:hover { border-color: var(--stroke-bright); transform: translateY(-3px); }
+  .ask-role { display: flex; align-items: center; gap: 9px; margin-bottom: 12px; }
+  .ask-role-av {
+    width: 26px; height: 26px; border-radius: 50%;
+    display: grid; place-items: center;
+    font-family: var(--display); font-weight: 600; font-size: 11px; color: #fff;
+    border: 1.5px solid rgba(255,255,255,0.25);
+  }
+  .ask-role-name {
+    font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--text-faint);
+  }
+  .ask-q {
+    font-family: var(--display); font-weight: 500; font-size: 17px;
+    letter-spacing: -0.01em; line-height: 1.35;
+  }
+  .ask-q::before { content: '“'; color: var(--blue); }
+  .ask-q::after { content: '”'; color: var(--blue); }
+  .ask-a {
+    margin-top: 10px;
+    font-family: var(--mono); font-size: 11.5px; color: var(--text-faint);
+    letter-spacing: 0.02em;
+  }
+  .ask-a span { color: var(--green); }
+
+  /* ---------- how it works ---------- */
+  .how-section { padding: 90px 0 20px; text-align: center; }
+  .how { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; max-width: 900px; margin: 40px auto 0; text-align: left; }
+  @media (max-width: 720px) { .how { grid-template-columns: 1fr; } }
+  .how-item {
+    background: var(--glass);
+    border: 1px solid var(--stroke);
+    border-radius: 18px; padding: 24px 24px 26px;
+    backdrop-filter: blur(10px);
+    transition: border-color 0.2s, transform 0.2s;
+  }
+  .how-item:hover { border-color: var(--stroke-bright); transform: translateY(-3px); }
+  .how-num {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.16em;
+    background: var(--grad);
+    -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
+    margin-bottom: 12px;
+  }
+  .how-title { font-family: var(--display); font-weight: 600; font-size: 18px; margin-bottom: 6px; }
+  .how-desc { font-size: 14px; color: var(--text-dim); line-height: 1.55; }
+
+  /* ---------- email gate (HubSpot embed) ---------- */
+  .hidden { display: none; }
+  .fade-in { animation: rise 0.6s cubic-bezier(0.16,1,0.3,1) both; }
+  .gate-section { padding: 90px 0 30px; }
+  .gate-card {
+    max-width: 600px; margin: 0 auto;
+    border-radius: 24px; padding: 1px;
+    background: linear-gradient(160deg, rgba(125,169,255,0.4), rgba(255,255,255,0.06) 45%, rgba(167,139,250,0.3));
+    box-shadow: 0 30px 90px rgba(0,0,0,0.5);
+  }
+  .gate-inner {
+    background: #0B0D12; border-radius: 23px;
+    padding: 46px 42px 42px; text-align: center;
+  }
+  .gate-inner .section-title { font-size: clamp(26px, 3.6vw, 34px); }
+  .hs-form-frame { margin-top: 28px; text-align: left; }
+  .form-note { font-size: 12px; color: var(--text-faint); margin-top: 16px; font-family: var(--mono); }
+
+  footer {
+    border-top: 1px solid var(--stroke);
+    margin-top: 70px;
+    padding: 28px 0 42px;
+    display: flex; align-items: center; justify-content: space-between;
+    flex-wrap: wrap; gap: 12px;
+    font-size: 13px; color: var(--text-faint);
+  }
+  footer a { color: var(--text-dim); text-decoration: none; }
+  footer a:hover { color: var(--text); }
+  .skip-link { font-family: var(--mono); font-size: 11.5px; }
+  </style>
+</head>
+<body>
+
+<PostHogInit client:load />
+
+<div class="aurora"></div>
+<svg class="grain" width="100%" height="100%">
+  <filter id="noise"><feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="2" stitchTiles="stitch"/><feColorMatrix type="saturate" values="0"/></filter>
+  <rect width="100%" height="100%" filter="url(#noise)" opacity="0.18"/>
+</svg>
+
+<div class="wrap">
+
+  <nav>
+    <a class="logo" href="https://desktopcommander.app/"><div class="logo-mark">DC</div>Desktop&nbsp;Commander</a>
+    <div class="nav-note"><span class="dot-live"></span>MCP connected</div>
+  </nav>
+
+  <!-- ============ HERO: INSTALLED ============ -->
+  <header>
+    <div class="hero-card">
+      <div class="status-line">✓ MCP server installed</div>
+      <div class="check-big">
+        <svg width="32" height="32" viewBox="0 0 32 32" fill="none"><path d="M8 16.5L13.5 22L24 11" stroke="#4ADE80" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </div>
+      <h1>Installed. You're all&nbsp;set.</h1>
+      <p class="sub">Thanks for installing the Desktop Commander MCP. It's connected to Claude. <strong>Nothing else to do</strong>. Switch over and start working.</p>
+      <div class="hero-skip">
+        <a href="https://desktopcommander.app/#prompts">Need a starting point? Browse 72+ prompts →</a>
+      </div>
+    </div>
+
+    <div class="scroll-cue" id="scrollCue" role="button" aria-label="Scroll to see what's new">
+      <svg width="26" height="26" viewBox="0 0 22 22" fill="none"><path d="M5 8l6 6 6-6" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+    </div>
+
+    <div class="divider"><span>while you're here · new</span></div>
+  </header>
+
+  <!-- ============ PITCH: SHARED AGENT ============ -->
+  <section class="pitch">
+    <h2>Get your <span class="grad">AI employee.</span></h2>
+    <p class="sub">A shared agent that does work for your team, with <strong>shared files</strong>, <strong>shared tools</strong>, and <strong>its own computer</strong>. Everyone can talk to it.</p>
+
+    <div class="btn-row">
+      <button class="btn" data-cta="hero">Create your shared agent →</button>
+    </div>
+  </section>
+
+  <!-- ============ PRODUCT DEMO ============ -->
+  <section class="demo-section">
+    <div class="section-kicker">See it work</div>
+    <h2 class="section-title">Task it like a teammate.</h2>
+    <p class="section-sub">Ask in chat. It connects to your systems, does the work on its own computer, and delivers the result.</p>
+
+    <div class="demo-shell">
+      <div class="demo-window">
+        <div class="demo-bar">
+          <div class="demo-dot r"></div><div class="demo-dot y"></div><div class="demo-dot g"></div>
+          <span class="demo-title"># team · Your AI employee</span>
+          <div class="demo-members">
+            <div class="demo-mini-av" style="background:#E8912D">M</div>
+            <div class="demo-mini-av" style="background:#3D7BE8">J</div>
+            <div class="demo-mini-av" style="background:#15181F;font-family:var(--mono)">DC</div>
           </div>
+          <span class="demo-status"><span class="sdot"></span>online</span>
+        </div>
+        <div class="demo-body" id="demoBody"></div>
+      </div>
+    </div>
+  </section>
 
-          <h1 class="text-3xl sm:text-4xl md:text-[2.75rem] lg:text-5xl font-bold text-foreground leading-[1.1] tracking-tight mb-4 text-balance">
-            You're all set.
-            <span class="text-primary">Nothing else to install.</span>
-          </h1>
-          <p class="text-base sm:text-lg text-muted-foreground max-w-xl mx-auto leading-relaxed">
-            Pick a prompt below, switch to Claude Desktop, and paste.
-          </p>
-        </header>
+  <!-- ============ TALK TO YOUR STUFF ============ -->
+  <section class="stuff-section">
+    <div class="section-kicker">Connect everything</div>
+    <h2 class="section-title">Connect your tools.<br>Talk to your stuff.</h2>
+    <p class="section-sub">Plug in the systems your company already runs on: ERP, CRM, databases, drives. Ask in plain language, and answers, reports, and changes come back done.</p>
 
-        <!-- Step 1: Starter prompts (grouped in a soft container so it doesn't float) -->
-        <section class="relative mb-10 md:mb-12 p-6 md:p-8 rounded-2xl bg-dc-surface/25 border border-dc-border/40">
-          <!-- Step chip + label -->
-          <div class="flex items-center justify-center gap-2.5 mb-5">
-            <span class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-primary text-white text-xs font-bold font-mono">1</span>
-            <span class="text-[11px] font-semibold uppercase tracking-[0.1em] text-muted-foreground font-mono">
-              Tap any prompt to copy
-            </span>
+    <div class="tool-cloud">
+      <span class="cloud-pill hl">SAP</span>
+      <span class="cloud-pill hl">NetSuite</span>
+      <span class="cloud-pill hl">Odoo</span>
+      <span class="cloud-pill">Salesforce</span>
+      <span class="cloud-pill">HubSpot</span>
+      <span class="cloud-pill">Postgres</span>
+      <span class="cloud-pill">MySQL</span>
+      <span class="cloud-pill">Google Drive</span>
+      <span class="cloud-pill">SharePoint</span>
+      <span class="cloud-pill">Notion</span>
+      <span class="cloud-pill">GitHub</span>
+      <span class="cloud-pill">Stripe</span>
+      <span class="cloud-pill">Shopify</span>
+      <span class="cloud-pill">Airtable</span>
+      <span class="cloud-pill">+ any MCP</span>
+    </div>
+
+    <div class="ask-grid">
+      <div class="ask-card">
+        <div class="ask-role"><div class="ask-role-av" style="background:#E8912D">M</div><div class="ask-role-name">Finance asks</div></div>
+        <div class="ask-q">Which invoices are overdue in NetSuite, by customer?</div>
+        <div class="ask-a"><span>→</span> table + reminder drafts, 40 sec</div>
+      </div>
+      <div class="ask-card">
+        <div class="ask-role"><div class="ask-role-av" style="background:#3D7BE8">J</div><div class="ask-role-name">Sales asks</div></div>
+        <div class="ask-q">Pull this quarter's pipeline by stage from Salesforce.</div>
+        <div class="ask-a"><span>→</span> chart + summary, posted to the team</div>
+      </div>
+      <div class="ask-card">
+        <div class="ask-role"><div class="ask-role-av" style="background:#9D5BD2">A</div><div class="ask-role-name">Ops asks</div></div>
+        <div class="ask-q">How many orders shipped late this week, and why?</div>
+        <div class="ask-a"><span>→</span> root-cause digest from ERP + logs</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ HOW IT WORKS ============ -->
+  <section class="how-section">
+    <div class="section-kicker">From install to agent</div>
+    <h2 class="section-title">How it works</h2>
+    <div class="how">
+      <div class="how-item">
+        <div class="how-num">01 · HIRE</div>
+        <div class="how-title">Hire an agent for your team</div>
+        <div class="how-desc">It gets its own computer in the cloud and is ready to work in minutes. No software to install, nothing to maintain.</div>
+      </div>
+      <div class="how-item">
+        <div class="how-num">02 · CONNECT</div>
+        <div class="how-title">Connect your tools</div>
+        <div class="how-desc">Plug in the things your company already uses: files, spreadsheets, ERP, CRM, databases. Connect once, and the whole team is covered.</div>
+      </div>
+      <div class="how-item">
+        <div class="how-num">03 · TALK</div>
+        <div class="how-title">Let everyone talk to it</div>
+        <div class="how-desc">Your team messages the agent in Slack, Teams, or the browser. Ask for something, and it comes back done.</div>
+      </div>
+    </div>
+
+    <div class="btn-row">
+      <button class="btn" data-cta="bottom">Create your shared agent →</button>
+    </div>
+    <div class="btn-note">early access · limited team slots</div>
+  </section>
+
+  <!-- ============ EMAIL GATE (HubSpot) ============ -->
+  <section class="gate-section hidden" id="gate">
+    <div class="gate-card">
+      <div class="gate-inner">
+        <div class="section-kicker">Early access</div>
+        <h2 class="section-title">Create your shared agent</h2>
+        <p class="section-sub">We're onboarding teams in small batches. Leave your company email and we'll reach out when your team's slot opens.</p>
+        <div class="hs-form-frame" data-region="eu1" data-form-id="733e0a8d-9b22-4a87-8872-f2196531544c" data-portal-id="146727725"></div>
+        <p class="form-note">no spam · one email when your team's slot opens</p>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div>© 2026 Desktop Commander · MIT-licensed MCP server</div>
+    <a class="skip-link" href="https://desktopcommander.app/#prompts">Just want the prompts? Browse 72+ →</a>
+  </footer>
+</div>
+
+<script is:inline>
+/* ============================================================
+   TRACKING — PostHog
+   posthog-js is initialized by the PostHogInit island (after
+   Cookiebot statistics consent). Events fired before it loads
+   are queued and flushed once it's ready.
+   Funnel: page_view → cta_clicked (hero|bottom) → gate_viewed
+           → email_submitted
+   ============================================================ */
+const EXPERIMENT = 'lp-a-team-agent';
+const _trackQueue = [];
+function phReady() {
+  return typeof window.posthog !== 'undefined' && typeof window.posthog.capture === 'function' && window.posthog.__loaded;
+}
+function track(event, props = {}) {
+  const payload = { experiment: EXPERIMENT, ...props };
+  if (phReady()) {
+    window.posthog.capture(event, payload);
+  } else {
+    _trackQueue.push([event, payload]);
+  }
+}
+const _flushTimer = setInterval(() => {
+  if (!phReady()) return;
+  while (_trackQueue.length) {
+    const [e, p] = _trackQueue.shift();
+    window.posthog.capture(e, p);
+  }
+  clearInterval(_flushTimer);
+}, 500);
+track('page_view');
+
+/* ---------- scroll cue ---------- */
+document.getElementById('scrollCue').addEventListener('click', () => {
+  document.querySelector('.pitch').scrollIntoView({ behavior: 'smooth', block: 'start' });
+});
+
+/* ---------- product demo animation (looping) ---------- */
+const demoBody = document.getElementById('demoBody');
+let demoTimers = [];
+function dWait(fn, ms) { demoTimers.push(setTimeout(fn, ms)); }
+
+function addUserMsg(name, initial, color, alt) {
+  const row = document.createElement('div');
+  row.className = 'd-user-row';
+  row.innerHTML = `
+    <div class="d-uavatar" style="background:${color}">${initial}</div>
+    <div>
+      <div class="d-uname">${name}</div>
+      <div class="d-user${alt ? ' alt' : ''}"><span class="dTyped"></span><span class="caret"></span></div>
+    </div>
+  `;
+  demoBody.appendChild(row);
+  return row;
+}
+
+function typeInto(row, text, startDelay) {
+  const typed = row.querySelector('.dTyped');
+  text.split('').forEach((ch, i) => {
+    dWait(() => { typed.textContent += ch; }, startDelay + i * 26);
+  });
+  const done = startDelay + text.length * 26;
+  dWait(() => { const c = row.querySelector('.caret'); if (c) c.remove(); }, done + 200);
+  return done;
+}
+
+function showPresence(name) {
+  const p = document.createElement('div');
+  p.className = 'd-presence'; p.id = 'dPresence';
+  p.textContent = name + ' is typing';
+  demoBody.appendChild(p);
+}
+function removePresence() {
+  const p = document.getElementById('dPresence');
+  if (p) p.remove();
+}
+
+function runDemo() {
+  demoTimers.forEach(clearTimeout);
+  demoTimers = [];
+  demoBody.style.opacity = 1;
+  demoBody.innerHTML = '';
+
+  /* 1 — presence, then employee #1 types the task */
+  const TASK1 = 'Generate the May sales report from our ERP. Revenue by region, vs. April.';
+  dWait(() => showPresence('Marta'), 300);
+  dWait(() => {
+    removePresence();
+    const marta = addUserMsg('Marta · Finance', 'M', '#E8912D', false);
+    typeInto(marta, TASK1, 0);
+  }, 1500);
+  const typeDone = 1500 + TASK1.length * 26;
+
+  /* 2 — agent works through steps */
+  const STEPS = [
+    'Connecting to NetSuite ERP',
+    'Pulling 1,284 May orders',
+    'Crunching numbers on my computer',
+    'Building charts + PDF'
+  ];
+  dWait(() => {
+    const agent = document.createElement('div');
+    agent.className = 'd-msg d-agent';
+    agent.innerHTML = `
+      <div class="d-avatar">DC</div>
+      <div class="d-bubble"><div class="d-steps" id="dSteps"></div></div>
+    `;
+    demoBody.appendChild(agent);
+  }, typeDone + 600);
+
+  STEPS.forEach((step, i) => {
+    dWait(() => {
+      const steps = document.getElementById('dSteps');
+      if (!steps) return;
+      /* mark previous as done */
+      const prev = steps.lastElementChild;
+      if (prev) { prev.classList.add('done'); prev.querySelector('.ic').innerHTML = '✓'; }
+      const el = document.createElement('div');
+      el.className = 'd-step';
+      el.innerHTML = `<span class="ic"><span class="spin"></span></span>${step}…`;
+      steps.appendChild(el);
+    }, typeDone + 900 + i * 1100);
+  });
+  const stepsDone = typeDone + 900 + STEPS.length * 1100;
+  dWait(() => {
+    const steps = document.getElementById('dSteps');
+    if (!steps) return;
+    const prev = steps.lastElementChild;
+    if (prev) { prev.classList.add('done'); prev.querySelector('.ic').innerHTML = '✓'; }
+  }, stepsDone);
+
+  /* 3 — result: report card with chart + file */
+  dWait(() => {
+    const result = document.createElement('div');
+    result.className = 'd-msg d-agent';
+    result.innerHTML = `
+      <div class="d-avatar">DC</div>
+      <div class="d-bubble" id="dResultBubble">
+        Done. May revenue <strong>€412k, +9% vs April</strong>. Strongest region: DACH. Full report attached.
+        <div class="d-report">
+          <div class="d-report-head">
+            <span class="d-report-title">Revenue by region · May</span>
+            <span class="d-report-tag">LIVE DATA</span>
           </div>
-
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-3.5 mb-5">
-          <button
-            type="button"
-            class="copyable-prompt flex items-center gap-3.5 px-4 md:px-5 py-4 bg-dc-surface/60 hover:bg-dc-surface border border-dc-border/60 hover:border-primary/50 rounded-lg text-left text-foreground transition-colors group"
-            data-prompt="Organize my Downloads folder by file type"
-            data-prompt-slug="organize-downloads"
-            data-prompt-title="Organize Downloads"
-          >
-            <span class="shrink-0 text-primary/80" aria-hidden="true">
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z"/></svg>
-            </span>
-            <span class="flex-1 text-sm">Organize my Downloads folder by file type</span>
-            <span class="shrink-0 text-muted-foreground group-hover:text-foreground transition-colors" aria-hidden="true">
-              <svg class="copy-icon" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
-              <svg class="check-icon hidden text-green-400" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
-            </span>
-          </button>
-
-          <button
-            type="button"
-            class="copyable-prompt flex items-center gap-3.5 px-4 md:px-5 py-4 bg-dc-surface/60 hover:bg-dc-surface border border-dc-border/60 hover:border-primary/50 rounded-lg text-left text-foreground transition-colors group"
-            data-prompt="Explain this codebase to me"
-            data-prompt-slug="explain-codebase"
-            data-prompt-title="Explain Codebase"
-          >
-            <span class="shrink-0 text-primary/80" aria-hidden="true">
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16 18 22 12 16 6"/><path d="M8 6 2 12 8 18"/></svg>
-            </span>
-            <span class="flex-1 text-sm">Explain this codebase to me</span>
-            <span class="shrink-0 text-muted-foreground group-hover:text-foreground transition-colors" aria-hidden="true">
-              <svg class="copy-icon" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
-              <svg class="check-icon hidden text-green-400" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
-            </span>
-          </button>
-
-          <button
-            type="button"
-            class="copyable-prompt flex items-center gap-3.5 px-4 md:px-5 py-4 bg-dc-surface/60 hover:bg-dc-surface border border-dc-border/60 hover:border-primary/50 rounded-lg text-left text-foreground transition-colors group"
-            data-prompt="Analyze my data file and show insights"
-            data-prompt-slug="analyze-data"
-            data-prompt-title="Analyze Data File"
-          >
-            <span class="shrink-0 text-primary/80" aria-hidden="true">
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="20" x2="12" y2="10"/><line x1="18" y1="20" x2="18" y2="4"/><line x1="6" y1="20" x2="6" y2="16"/></svg>
-            </span>
-            <span class="flex-1 text-sm">Analyze my data file</span>
-            <span class="shrink-0 text-muted-foreground group-hover:text-foreground transition-colors" aria-hidden="true">
-              <svg class="copy-icon" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
-              <svg class="check-icon hidden text-green-400" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
-            </span>
-          </button>
-
-          <button
-            type="button"
-            class="copyable-prompt flex items-center gap-3.5 px-4 md:px-5 py-4 bg-dc-surface/60 hover:bg-dc-surface border border-dc-border/60 hover:border-primary/50 rounded-lg text-left text-foreground transition-colors group"
-            data-prompt="Extract data from my PDF files"
-            data-prompt-slug="extract-pdf"
-            data-prompt-title="Extract from PDFs"
-          >
-            <span class="shrink-0 text-primary/80" aria-hidden="true">
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="9" y1="13" x2="15" y2="13"/><line x1="9" y1="17" x2="13" y2="17"/></svg>
-            </span>
-            <span class="flex-1 text-sm">Extract data from PDFs</span>
-            <span class="shrink-0 text-muted-foreground group-hover:text-foreground transition-colors" aria-hidden="true">
-              <svg class="copy-icon" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
-              <svg class="check-icon hidden text-green-400" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
-            </span>
-          </button>
-        </div>
-
-        <div class="text-center">
-          <a
-            id="browse-all-prompts"
-            href="/library/prompts/"
-            class="inline-block text-sm text-muted-foreground hover:text-foreground transition-colors py-2"
-          >
-            Browse all 72+ prompts →
-          </a>
-        </div>
-        </section>
-
-        <!-- Connector arrow between step 1 (pick) and step 2 (paste) -->
-        <div class="flex justify-center mb-10 md:mb-12" aria-hidden="true">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="28" viewBox="0 0 20 28" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="text-muted-foreground/60">
-            <line x1="10" y1="2" x2="10" y2="22"/>
-            <polyline points="3 17 10 24 17 17"/>
-          </svg>
-        </div>
-
-        <!-- Step 2: Paste in Claude Desktop -->
-        <div class="flex items-center justify-center gap-2.5 mb-6">
-          <span class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-primary text-white text-xs font-bold font-mono">2</span>
-          <span class="text-[11px] font-semibold uppercase tracking-[0.1em] text-muted-foreground font-mono">
-            Now paste into Claude Desktop
-          </span>
-        </div>
-
-        <div class="mb-14 md:mb-16 flex justify-center">
-          <div class="relative w-full max-w-md">
-            <div class="absolute -inset-4 bg-primary/10 blur-3xl rounded-full pointer-events-none" aria-hidden="true"></div>
-            <div class="relative bg-[#f5f2ec] rounded-2xl p-5 shadow-[0_20px_60px_-15px_rgba(0,0,0,0.5)] border border-black/5">
-              <!-- Fake window chrome to frame as an app -->
-              <div class="flex items-center gap-1.5 mb-4" aria-hidden="true">
-                <span class="w-2.5 h-2.5 rounded-full bg-[#e06c5c]"></span>
-                <span class="w-2.5 h-2.5 rounded-full bg-[#f0b14b]"></span>
-                <span class="w-2.5 h-2.5 rounded-full bg-[#7bc36b]"></span>
-                <span class="ml-auto text-[10px] font-medium text-stone-500 tracking-wide">Claude Desktop</span>
-              </div>
-              <!-- Claude chat input mock -->
-              <div class="bg-white border border-stone-200 rounded-xl px-4 py-3 shadow-sm">
-                <div class="text-[15px] text-stone-700 min-h-[22px]" id="claude-typed">
-                  Organize my Downloads folder by file type<span class="inline-block w-[2px] h-[17px] bg-stone-700 align-[-3px] ml-[1px] animate-caret"></span>
-                </div>
-                <div class="flex items-center gap-2 mt-3 pt-1 text-stone-400 text-xs">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-                  <span class="mr-auto font-medium">Claude Opus</span>
-                  <span class="inline-flex items-center justify-center w-6 h-6 rounded-md bg-[#c96c4c] text-white">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
-                  </span>
-                </div>
-              </div>
-              <p class="text-center text-[11px] text-stone-500 mt-3 font-mono tracking-wide">
-                ↑ paste your prompt here and hit send
-              </p>
+          <div class="d-chart" id="dChart">
+            <span data-h="58"></span><span data-h="34"></span><span data-h="72"></span><span data-h="46"></span><span data-h="26"></span><span data-h="64"></span>
+          </div>
+          <div class="d-chart-labels"><i>DACH</i><i>UK</i><i>FR</i><i>NORD</i><i>ES</i><i>US</i></div>
+          <div class="d-file">
+            <div class="d-file-ic">PDF</div>
+            <div>
+              <div class="d-file-name">may-sales-report.pdf</div>
+              <div class="d-file-meta">6 pages · charts + tables · just now</div>
             </div>
           </div>
         </div>
-
-        <!-- Troubleshooting -->
-        <div class="p-4 md:p-5 mb-14 md:mb-16 rounded-lg border border-amber-500/35 bg-amber-500/[0.07] text-sm leading-relaxed text-amber-100/90">
-          <strong class="font-semibold text-amber-100">Not working in Claude?</strong>
-          Open
-          <code class="inline-block px-1.5 py-0.5 mx-0.5 rounded bg-amber-500/15 text-amber-200 font-mono text-[12.5px]">Settings → Connectors</code>,
-          toggle Desktop Commander on, and approve its tools.
-        </div>
-
-        <!-- Newsletter (always visible) -->
-        <section class="mb-12 p-6 md:p-8 rounded-2xl border border-dc-border bg-dc-card/30 text-center">
-          <div class="inline-flex items-center justify-center w-12 h-12 mb-4 rounded-full bg-primary/15 text-primary">
-            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <rect width="20" height="16" x="2" y="4" rx="2"/>
-              <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
-            </svg>
-          </div>
-          <h2 class="text-xl md:text-2xl font-semibold text-foreground mb-2">Weekly prompt ideas for Claude Desktop</h2>
-          <p class="text-sm text-muted-foreground max-w-md mx-auto mb-5">
-            Get new prompts, automation tips, and feature updates in your inbox. No spam, unsubscribe anytime.
-          </p>
-          <div class="hubspot-form-wrapper max-w-sm mx-auto">
-            <script src="https://js-eu1.hsforms.net/forms/embed/146727725.js" defer></script>
-            <div class="hs-form-frame" data-region="eu1" data-form-id="5fc2eb78-4b8b-4f64-a213-37d0fbb86a50" data-portal-id="146727725"></div>
-          </div>
-          <p class="text-xs text-muted-foreground mt-3">
-            <a href="https://legal.desktopcommander.app/website_privacy_policy" target="_blank" rel="noopener noreferrer" class="text-primary hover:text-primary/80 underline">Privacy Policy</a>
-          </p>
-        </section>
-
-        <!-- Quiet utility footer -->
-        <div class="flex items-center justify-center gap-6 md:gap-8 pt-7 border-t border-dc-border/60 text-sm text-muted-foreground">
-          <a href="https://discord.gg/eHZeUKRQG" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 hover:text-foreground transition-colors">
-            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
-            </svg>
-            Discord
-          </a>
-          <a href="https://github.com/wonderwhy-er/DesktopCommanderMCP" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 hover:text-foreground transition-colors">
-            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-            </svg>
-            GitHub
-          </a>
-        </div>
-
       </div>
-    </main>
+    `;
+    demoBody.appendChild(result);
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      document.querySelectorAll('#dChart span').forEach(b => { b.style.height = b.dataset.h + 'px'; });
+    }));
+  }, stepsDone + 500);
 
-    <Footer client:visible />
-  </div>
+  /* 4 — a third teammate reacts (no ask — just benefiting) */
+  dWait(() => {
+    const bubble = document.getElementById('dResultBubble');
+    if (!bubble) return;
+    const reacts = document.createElement('div');
+    reacts.className = 'd-reacts';
+    reacts.innerHTML = `
+      <span class="d-react">🔥 Aisha · Ops</span>
+      <span class="d-react" style="animation-delay:0.35s">👍 2</span>
+    `;
+    bubble.appendChild(reacts);
+  }, stepsDone + 2100);
 
-  <style>
-    .animate-fade-in-up {
-      animation: fade-in-up 0.5s ease-out both;
+  /* 5 — employee #2 jumps in */
+  const TASK2 = 'nice! @agent, same cut but just my UK accounts?';
+  dWait(() => showPresence('Jonas'), stepsDone + 3000);
+  dWait(() => {
+    removePresence();
+    const jonas = addUserMsg('Jonas · Sales', 'J', '#3D7BE8', true);
+    typeInto(jonas, TASK2, 0);
+  }, stepsDone + 4100);
+  const jonasDone = stepsDone + 4100 + TASK2.length * 26 + 400;
+
+  /* 6 — agent answers the second employee */
+  dWait(() => {
+    const reply2 = document.createElement('div');
+    reply2.className = 'd-msg d-agent';
+    reply2.innerHTML = `
+      <div class="d-avatar">DC</div>
+      <div class="d-bubble">
+        On it, Jonas. UK only: <strong>€86k, +14% vs April</strong>. Your top account: Harrod &amp; Co.
+        <div class="d-file" style="border-top:none;padding-top:4px">
+          <div class="d-file-ic" style="background:#3D7BE8">PDF</div>
+          <div>
+            <div class="d-file-name">may-sales-uk.pdf</div>
+            <div class="d-file-meta">3 pages · same data, your accounts · just now</div>
+          </div>
+        </div>
+      </div>
+    `;
+    demoBody.appendChild(reply2);
+  }, jonasDone + 900);
+
+  /* 7 — hold, fade, loop */
+  dWait(() => { demoBody.style.opacity = 0; }, jonasDone + 7000);
+  dWait(runDemo, jonasDone + 7600);
+}
+
+/* start when scrolled into view */
+const demoObserver = new IntersectionObserver(entries => {
+  if (entries[0].isIntersecting) {
+    runDemo();
+    demoObserver.disconnect();
+    track('demo_viewed');
+  }
+}, { threshold: 0.35 });
+demoObserver.observe(demoBody);
+
+/* ---------- CTA → gate ---------- */
+document.querySelectorAll('[data-cta]').forEach(btn => {
+  btn.addEventListener('click', () => {
+    track('cta_clicked', { position: btn.dataset.cta });
+    const gate = document.getElementById('gate');
+    const wasHidden = gate.classList.contains('hidden');
+    gate.classList.remove('hidden');
+    gate.classList.add('fade-in');
+    gate.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    if (wasHidden) track('gate_viewed', { position: btn.dataset.cta });
+  });
+});
+
+/* ---------- HubSpot form events ---------- */
+window.addEventListener('message', (event) => {
+  const d = event.data;
+  if (!d || d.type !== 'hsFormCallback') return;
+  if (d.eventName === 'onFormReady') {
+    track('hs_form_ready');
+  }
+  if (d.eventName === 'onFormSubmitted') {
+    track('email_submitted', { form_id: d.id });
+    if (phReady()) {
+      const email = d.data && d.data.submissionValues && d.data.submissionValues.email;
+      if (email) window.posthog.identify(email, { email });
     }
-    @keyframes fade-in-up {
-      from { opacity: 0; transform: translateY(12px); }
-      to   { opacity: 1; transform: translateY(0); }
-    }
-    .animate-caret {
-      animation: caret 1s steps(2, start) infinite;
-    }
-    @keyframes caret {
-      to { visibility: hidden; }
-    }
-    @media (prefers-reduced-motion: reduce) {
-      .animate-fade-in-up,
-      .animate-caret { animation: none; }
-    }
-  </style>
-
-  <script is:inline>
-    // ---------- Copy a prompt ----------
-    function handleCopy(promptText, promptSlug, promptTitle, btn) {
-      navigator.clipboard.writeText(promptText).then(() => {
-        const copyIcon = btn.querySelector('.copy-icon');
-        const checkIcon = btn.querySelector('.check-icon');
-        const textSpan = btn.querySelector('span.flex-1');
-        const originalText = textSpan ? textSpan.textContent : '';
-
-        if (copyIcon && checkIcon) {
-          copyIcon.classList.add('hidden');
-          checkIcon.classList.remove('hidden');
-        }
-        if (textSpan) {
-          textSpan.textContent = '✓ Copied — paste in Claude Desktop';
-          textSpan.classList.add('text-green-400');
-        }
-        setTimeout(() => {
-          if (copyIcon && checkIcon) {
-            copyIcon.classList.remove('hidden');
-            checkIcon.classList.add('hidden');
-          }
-          if (textSpan) {
-            textSpan.textContent = originalText;
-            textSpan.classList.remove('text-green-400');
-          }
-        }, 2500);
-
-        if (window.posthog) {
-          window.posthog.capture('welcome_prompt_copied', {
-            prompt_text: promptText,
-            prompt_slug: promptSlug,
-            prompt_title: promptTitle,
-            page: '/welcome/'
-          });
-        }
-      }).catch(err => console.error('Copy failed:', err));
-    }
-
-    document.querySelectorAll('.copyable-prompt').forEach(btn => {
-      btn.addEventListener('click', function() {
-        handleCopy(
-          this.dataset.prompt,
-          this.dataset.promptSlug || 'unknown',
-          this.dataset.promptTitle || 'Unknown',
-          this
-        );
-        // Mirror the copied prompt into the Claude Desktop preview
-        const typed = document.getElementById('claude-typed');
-        if (typed) {
-          typed.innerHTML = this.dataset.prompt +
-            '<span class="inline-block w-[2px] h-[17px] bg-stone-700 align-[-3px] ml-[1px] animate-caret"></span>';
-        }
-      });
-    });
-
-    // ---------- Browse-all tracking ----------
-    document.getElementById('browse-all-prompts')?.addEventListener('click', () => {
-      if (window.posthog) {
-        window.posthog.capture('welcome_browse_all_prompts_clicked', { page: '/welcome/' });
-      }
-    });
-
-    // ---------- Page-view event (so we can A/B) ----------
-    if (window.posthog) {
-      window.posthog.capture('welcome_page_viewed', { variant: 'welcome2', page: '/welcome/' });
-    }
-  </script>
-</Layout>
+  }
+});
+</script>
+</body>
+</html>

--- a/astro-src/pages/welcome.astro
+++ b/astro-src/pages/welcome.astro
@@ -519,24 +519,67 @@ const description =
 
   /* ---------- how it works ---------- */
   .how-section { padding: 90px 0 20px; text-align: center; }
-  .how { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; max-width: 900px; margin: 40px auto 0; text-align: left; }
-  @media (max-width: 720px) { .how { grid-template-columns: 1fr; } }
+  .how { display: flex; align-items: stretch; justify-content: center; gap: 0; max-width: 960px; margin: 46px auto 0; text-align: left; }
   .how-item {
+    position: relative; flex: 1; isolation: isolate; overflow: hidden;
     background: var(--glass);
     border: 1px solid var(--stroke);
-    border-radius: 18px; padding: 24px 24px 26px;
+    border-radius: 20px; padding: 26px 22px 30px;
     backdrop-filter: blur(10px);
-    transition: border-color 0.2s, transform 0.2s;
+    transition: transform 0.28s ease, box-shadow 0.28s ease, border-color 0.28s ease;
   }
-  .how-item:hover { border-color: var(--stroke-bright); transform: translateY(-3px); }
-  .how-num {
-    font-family: var(--mono); font-size: 11px; letter-spacing: 0.16em;
+  /* gradient hairline border that lights up on hover */
+  .how-item::after {
+    content: ''; position: absolute; inset: 0; border-radius: inherit; padding: 1px;
     background: var(--grad);
-    -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
-    margin-bottom: 12px;
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor; mask-composite: exclude;
+    opacity: 0; transition: opacity 0.3s ease; pointer-events: none;
   }
-  .how-title { font-family: var(--display); font-weight: 600; font-size: 18px; margin-bottom: 6px; }
-  .how-desc { font-size: 14px; color: var(--text-dim); line-height: 1.55; }
+  .how-item:hover { transform: translateY(-5px); border-color: transparent; box-shadow: 0 20px 55px rgba(125,169,255,0.14); }
+  .how-item:hover::after { opacity: 0.65; }
+  .how-head { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
+  .how-node {
+    position: relative; flex: none; width: 46px; height: 46px; border-radius: 50%;
+    display: grid; place-items: center;
+    background: radial-gradient(circle at 50% 32%, rgba(125,169,255,0.18), rgba(255,255,255,0.015));
+    transition: box-shadow 0.3s ease;
+  }
+  .how-node::before {
+    content: ''; position: absolute; inset: 0; border-radius: 50%; padding: 1.5px;
+    background: var(--grad);
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor; mask-composite: exclude;
+    opacity: 0.75; transition: opacity 0.3s ease;
+  }
+  .how-item:hover .how-node::before { opacity: 1; }
+  .how-item:hover .how-node { box-shadow: 0 0 22px rgba(167,139,250,0.35); }
+  .how-node b {
+    font-family: var(--display); font-weight: 700; font-size: 17px; line-height: 1;
+    background: var(--grad); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
+  }
+  .how-label { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--text-dim); }
+  .how-title { font-family: var(--display); font-weight: 600; font-size: 18px; margin: 0 0 7px; position: relative; z-index: 1; }
+  .how-desc { font-size: 14px; color: var(--text-dim); line-height: 1.5; margin: 0; position: relative; z-index: 1; }
+  /* faint oversized icon watermark for depth */
+  .how-wm {
+    position: absolute; right: -10px; bottom: -12px; width: 92px; height: 92px;
+    color: #A78BFA; opacity: 0.07; z-index: 0;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+  }
+  .how-item:hover .how-wm { opacity: 0.16; transform: translateY(-4px) rotate(-4deg); }
+  /* animated gradient connector */
+  .how-sep {
+    display: flex; align-items: center; padding: 0 8px; font-size: 22px; font-weight: 700; line-height: 1;
+    font-family: var(--display);
+    background: var(--grad); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
+    animation: howArrow 1.8s ease-in-out infinite;
+  }
+  @keyframes howArrow { 0%,100% { transform: translateX(0); opacity: 0.45; } 50% { transform: translateX(5px); opacity: 1; } }
+  @media (max-width: 720px) {
+    .how { flex-direction: column; gap: 12px; }
+    .how-sep { transform: rotate(90deg); padding: 4px 0; align-self: center; animation: none; opacity: 0.5; }
+  }
 
   /* ---------- email gate (HubSpot embed) ---------- */
   .hidden { display: none; }
@@ -688,21 +731,26 @@ const description =
     <div class="section-kicker">From install to agent</div>
     <h2 class="section-title">How it works</h2>
     <div class="how">
-      <div class="how-item">
-        <div class="how-num">01 · HIRE</div>
-        <div class="how-title">Hire an agent for your team</div>
-        <div class="how-desc">It gets its own computer in the cloud and is ready to work in minutes. No software to install, nothing to maintain.</div>
-      </div>
-      <div class="how-item">
-        <div class="how-num">02 · CONNECT</div>
-        <div class="how-title">Connect your tools</div>
-        <div class="how-desc">Plug in the things your company already uses: files, spreadsheets, ERP, CRM, databases. Connect once, and the whole team is covered.</div>
-      </div>
-      <div class="how-item">
-        <div class="how-num">03 · TALK</div>
-        <div class="how-title">Let everyone talk to it</div>
-        <div class="how-desc">Your team messages the agent in Slack, Teams, or the browser. Ask for something, and it comes back done.</div>
-      </div>
+      <article class="how-item">
+        <div class="how-head"><span class="how-node"><b>01</b></span><span class="how-label">Create</span></div>
+        <h3 class="how-title">Create a shared agent</h3>
+        <p class="how-desc">Set up once for your whole team.</p>
+        <svg class="how-wm" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2l1.7 5.1L19 9l-5.3 1.9L12 16l-1.7-5.1L5 9l5.3-1.9z"/><path d="M18.5 13.5l.7 2.1 2.1.7-2.1.7-.7 2.1-.7-2.1-2.1-.7 2.1-.7z"/></svg>
+      </article>
+      <div class="how-sep" aria-hidden="true">→</div>
+      <article class="how-item">
+        <div class="how-head"><span class="how-node"><b>02</b></span><span class="how-label">Connect</span></div>
+        <h3 class="how-title">Connect your tools</h3>
+        <p class="how-desc">The apps your team already uses.</p>
+        <svg class="how-wm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 12h6"/><path d="M10.5 8H8.5a4 4 0 000 8h2"/><path d="M13.5 8h2a4 4 0 010 8h-2"/></svg>
+      </article>
+      <div class="how-sep" aria-hidden="true">→</div>
+      <article class="how-item">
+        <div class="how-head"><span class="how-node"><b>03</b></span><span class="how-label">Talk</span></div>
+        <h3 class="how-title">Talk to it together</h3>
+        <p class="how-desc">Just ask — it gets things done.</p>
+        <svg class="how-wm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6.5A2.5 2.5 0 015.5 4h8A2.5 2.5 0 0116 6.5v4A2.5 2.5 0 0113.5 13H8l-3.5 3v-3H5.5A2.5 2.5 0 013 10.5z"/><path d="M16 9h2.5A2.5 2.5 0 0121 11.5v4A2.5 2.5 0 0118.5 18H18v2l-2.5-2H12.5"/></svg>
+      </article>
     </div>
 
     <div class="btn-row">


### PR DESCRIPTION
## What

Replaces the `/welcome/` page (post-install deeplink target) with the **a-team-agent** landing experiment: install confirmation hero → shared-agent pitch → looping chat demo → tool cloud → how-it-works → gated early-access waitlist.

## Key changes

- **Email capture via HubSpot embedded form** (portal 146727725, eu1, form `733e0a8d`) — replaces the old custom form; submissions land in HubSpot. The HubSpot script has `data-cookieconsent=ignore` so Cookiebot auto-blocking can't prevent the form from rendering (worth a compliance sanity check).
- **PostHog funnel**, all events tagged `experiment: lp-a-team-agent`:
  `page_view → demo_viewed → cta_clicked (hero|bottom) → gate_viewed → email_submitted` (+ `posthog.identify` on submit).
- **Standalone document** — does not use `Layout.astro` (design ships its own fonts/reset/styles); Cookiebot, GA, Ahrefs, favicons, canonical and OG meta are replicated inline. Keep in sync if Layout's head changes.
- Logo in nav links back to the main page.

## Not included

Built output (`docs/`) is **not** in this PR to keep the diff reviewable — run `npm run commit-static` (or rebuild) when merging to actually ship it.

## Tested locally

Build passes (102 pages). Verified in browser: demo animation, CTA → gate reveal, HubSpot form renders with dark styling, PostHog events fire. Form submission not exercised (would create a real HubSpot contact).

Old v2 page recoverable from git history; v1 still at `/welcome2/`.